### PR TITLE
bump cluster-dns module version

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -14,7 +14,7 @@ module "zone" {
 }
 
 module "external_dns" {
-  source                = "git::https://github.com/goci-io/aws-external-cluster-dns.git?ref=tags/0.4.0"
+  source                = "git::https://github.com/goci-io/aws-external-cluster-dns.git?ref=tags/0.4.1"
   namespace             = var.namespace
   stage                 = var.stage
   region                = var.region


### PR DESCRIPTION
includes a fix which allows to destroy and restore this module